### PR TITLE
Get results from iterator as tuples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ rs = executeQuery(stmt, "select * from firsttable")
  end
 ```
 
+To get each row as a julia tuple, iterate over the result set using `JDBCRowIterator`.  Values in the tuple will be of Nullable type if they are declared to be nullable in the database.
+
+```julia
+for r in JDBCRowIterator(rs)
+    println(r)
+end
+```
+
 The following accessor functions are defined. Each of these functions take two arguments:  the `Resultset`, and either a field index or a field name. The result of these accessor functions is always a pure Julia object. All conversions from Java types are done before they are returned from these functions. 
 ```julia
 getInt
@@ -75,6 +83,17 @@ Note that as per the JDBC API there are two kinds of execute methods defined on 
 Also note that for a `Statement`, the query itself is specified in the corresponding `execute..` call, while for a `PreparedStatement` and a `CallableStatement`, the query itself is specified while creating them. 
 
 The connections and the statements should be closed via their `close(...)` functions. `commit(connection)`, `rollaback(connection)` and `setAutoCommit(true|false)` do the obvious things. 
+
+###Metadata
+
+Pass the `JResultSet` object from `executeQuery` to `getTableMetaData` to get an array of `(column_name, column_type)` tuples.
+
+```julia
+conn = DriverManager.getConnection("jdbc:derby:test/juliatest")
+stmt = createStatement(conn)
+rs = executeQuery(stmt, "select * from firsttable")
+metadata = getTableMetaData(rs)
+```
 
 ###Caveats
  * BLOB's are not yet supported. 

--- a/src/JDBC.jl
+++ b/src/JDBC.jl
@@ -37,6 +37,9 @@ JPreparedStatement = @jimport java.sql.PreparedStatement
 JCallableStatement = @jimport java.sql.CallableStatement
 JConnection = @jimport java.sql.Connection
 
+const COLUMN_NO_NULLS = 0
+const COLUMN_NULLABLE = 1
+const COLUMN_NULLABLE_UNKNOWN = 2
 
 init() = JavaCall.init()
 
@@ -95,6 +98,7 @@ getMetaData(rs::JResultSet) = jcall(rs, "getMetaData", JResultSetMetaData, ())
 getColumnCount(rsmd::JResultSetMetaData) = jcall(rsmd, "getColumnCount", jint, ())
 getColumnType(rsmd::JResultSetMetaData, col::Integer) = jcall(rsmd, "getColumnType", jint, (jint,), col)
 getColumnName(rsmd::JResultSetMetaData, col::Integer) = jcall(rsmd, "getColumnName", JString, (jint,), col)
+isNullable(rsmd::JResultSetMetaData, col::Integer) = jcall(rsmd, "isNullable", jint, (jint,), col)
 
 @require DataFrames begin
 using DataFrames
@@ -236,15 +240,19 @@ type JDBCRowIterator
     rs::JResultSet
     ncols::Int
     get_methods::Array{Function, 1}
+    isnullable::Array{Int, 1}
 
     function JDBCRowIterator(rs::JResultSet)
         rsmd = getMetaData(rs)
         ncols = getColumnCount(rsmd)
         get_methods = Array(Function, ncols)
+        isnullable = Array(Int, ncols)
         for c in 1:ncols
             get_methods[c] = jdbc_get_method(getColumnType(rsmd, c))
+            isnullable[c] = isNullable(rsmd, c)
         end
-        new(rs, ncols, get_methods)
+
+        new(rs, ncols, get_methods, isnullable)
     end
 end
 
@@ -252,7 +260,14 @@ Base.start(iter::JDBCRowIterator) = true
 function Base.next(iter::JDBCRowIterator, state)
     row = Array(Any, iter.ncols)
     for c in 1:iter.ncols
-        row[c] = iter.get_methods[c](iter.rs, c)
+        val = iter.get_methods[c](iter.rs, c)
+        if wasNull(iter.rs)
+            row[c] = Nullable{typeof(val)}()
+        elseif iter.isnullable[c] == COLUMN_NULLABLE || iter.isnullable[c] == COLUMN_NULLABLE_UNKNOWN
+            row[c] = Nullable(val)
+        else
+            row[c] = val
+        end
     end       
         
     tuple(row...), state

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,23 @@ airlines=readtable(rs)
 
 close(rs)
 
+# Tests for `getTableMetaData` and `JDBCRowIterator`.`
+rs = executeQuery(stmt, "select * from airlines")
+iter = JDBCRowIterator(rs)
+airlines = collect(iter)
+
+@assert getTableMetaData(rs) == [("AIRLINE", 1), ("AIRLINE_FULL", 12), ("BASIC_RATE", 8),
+                                 ("DISTANCE_DISCOUNT", 8), ("BUSINESS_LEVEL_FACTOR", 8),
+                                 ("FIRSTCLASS_LEVEL_FACTOR", 8), ("ECONOMY_SEATS", 4),
+                                 ("BUSINESS_SEATS", 4), ("FIRSTCLASS_SEATS", 4)]
+@assert size(airlines) == (2,)
+@assert length(airlines[1]) == 9
+@assert airlines[1][3] == 0.18
+@assert airlines[2][3] == 0.19
+@assert airlines[1][7] == 20
+@assert airlines[1][1] == "AA"
+close(rs)
+
 rs = executeQuery(stmt, "select * from flights")
 flights=readtable(rs)
 size(flights) == (542,10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,10 +32,15 @@ rs = executeQuery(stmt, "select * from airlines")
 iter = JDBCRowIterator(rs)
 airlines = collect(iter)
 
-@assert getTableMetaData(rs) == [("AIRLINE", 1), ("AIRLINE_FULL", 12), ("BASIC_RATE", 8),
-                                 ("DISTANCE_DISCOUNT", 8), ("BUSINESS_LEVEL_FACTOR", 8),
-                                 ("FIRSTCLASS_LEVEL_FACTOR", 8), ("ECONOMY_SEATS", 4),
-                                 ("BUSINESS_SEATS", 4), ("FIRSTCLASS_SEATS", 4)]
+@assert getTableMetaData(rs) == [("AIRLINE", JDBC.JDBC_COLTYPE_CHAR),
+                                 ("AIRLINE_FULL", JDBC.JDBC_COLTYPE_VARCHAR),
+                                 ("BASIC_RATE", JDBC.JDBC_COLTYPE_DOUBLE),
+                                 ("DISTANCE_DISCOUNT", JDBC.JDBC_COLTYPE_DOUBLE),
+                                 ("BUSINESS_LEVEL_FACTOR", JDBC.JDBC_COLTYPE_DOUBLE),
+                                 ("FIRSTCLASS_LEVEL_FACTOR", JDBC.JDBC_COLTYPE_DOUBLE),
+                                 ("ECONOMY_SEATS", JDBC.JDBC_COLTYPE_INTEGER),
+                                 ("BUSINESS_SEATS", JDBC.JDBC_COLTYPE_INTEGER),
+                                 ("FIRSTCLASS_SEATS", JDBC.JDBC_COLTYPE_INTEGER)]
 @assert size(airlines) == (2,)
 @assert length(airlines[1]) == 9
 @assert airlines[1][3] == 0.18

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,9 +43,9 @@ airlines = collect(iter)
                                  ("FIRSTCLASS_SEATS", JDBC.JDBC_COLTYPE_INTEGER)]
 @assert size(airlines) == (2,)
 @assert length(airlines[1]) == 9
-@assert airlines[1][3] == 0.18
-@assert airlines[2][3] == 0.19
-@assert airlines[1][7] == 20
+@assert airlines[1][3].value == 0.18
+@assert airlines[2][3].value == 0.19
+@assert airlines[1][7].value == 20
 @assert airlines[1][1] == "AA"
 close(rs)
 


### PR DESCRIPTION
* Created a new type `JDBCRowIterator` that iterates over rows and returns a row as a tuple.
* Added a function `getTableMetaData` that returns an array of `(column_name, column_type)` tuples.
* Added tests for both in `runtests.jl`.
* Test passing for julia 0.3 and 0.4