### PR TITLE
allow passing of parameters to init()

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ The JVM remains in memory unless you explicitly destroy it.  This can be done wi
 JDBC.destroy() # or JavaCall.destroy()
 ```
 
+Some drivers require special parameters for the initialization of the JVM,
+which can be passed to `init()` as a vector of `String`s, e.g.
+```julia
+JDBC.init(["--add-opens=java.base/java.nio=ALL-UNNAMED"])
+```
+
 ### Low-Level Java Interface
 
 As described above, this package provides functionality very similar to using a JDBC driver in Java. This allows you to write code very similar to how it would

--- a/src/JDBC.jl
+++ b/src/JDBC.jl
@@ -37,8 +37,8 @@ const COLUMN_NO_NULLS = 0
 const COLUMN_NULLABLE = 1
 const COLUMN_NULLABLE_UNKNOWN = 2
 
-init() = JavaCall.init()
-destroy() = JavaCall.destroy()
+const init = JavaCall.init
+const destroy = JavaCall.destroy
 
 """
 ```


### PR DESCRIPTION
This a PR to #62 for allowing the passing of parameters to `init()`.

I chose to define constants rather than `using JavaCall: init` as I found that tab-completion did not work in that case.